### PR TITLE
Implemented linkSelector and formSelector options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,13 @@ Here are the available options for loading the Schmick library:
     // you can enter the script src urls here and these will be re-executed
     // on every page load.
     scriptsToReload: [],
-    
+
+    // Links matching this selector are handled by Schmick.
+    linkSelector: 'a[href]',
+
+    // Forms matching this selector are handled by Schmick.
+    formSelector: 'form',
+
     // The animation effect options
     // This library uses jQuery UI to perform the animations
     // any options supported by jQuery can be specified here.

--- a/schmick.js
+++ b/schmick.js
@@ -18,6 +18,8 @@ window.Schmick = (function(window, $) {
         self.defaults = {
             container: 'body',
             scriptsToReload: [],
+            linkSelector: 'a[href]',
+            formSelector: 'form',
             effects: {
                 hide: { effect: 'fade', duration: 300 },
                 show: { effect: 'fade', duration: 300 }
@@ -82,6 +84,8 @@ window.Schmick = (function(window, $) {
      * Schmick.load({
      *      container: 'body',
      *      scriptsToReload: [],
+     *      linkSelector: 'a[href]',
+     *      formSelector: 'form',
      *      effects: {
      *          hide: { effect: 'fade', duration: 300 },
      *          show: { effect: 'fade', duration: 300 }
@@ -112,8 +116,8 @@ window.Schmick = (function(window, $) {
 
         schmick.options = $.extend(true, {}, schmick.defaults, options);
 
-        $(document).on('click', 'a[href]', handleLinkClick);
-        $(document).on('submit', 'form', handleFormSubmission);
+        $(document).on('click', schmick.options.linkSelector, handleLinkClick);
+        $(document).on('submit', schmick.options.formSelector, handleFormSubmission);
         $(window).on('popstate', handlePopState);
 
         window.__schmick = schmick;


### PR DESCRIPTION
I have moved the link and form selectors into the options object to allow Schmick to be applied more specifically.
### Examples

``` javascript
    Schmick.load({
        linkSelector: '.sidebar a[href]',
    });
```

``` javascript
    Schmick.load({
        linkSelector: 'a[href].ajax-link',
    });
```

``` javascript
    Schmick.load({
        formSelector: '.ajax-form',
    });
```
