### PR TITLE
Pass the new document as an argument to beforeContainersReplaced and afterContainersReplaced events

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ Here are the available options for loading the Schmick library:
         newPageDownloadProgress: function (percentage) { },
         
         // Called before the container old elements are replaced
-        beforeContainersReplaced: function () {},
+        beforeContainersReplaced: function (newDoc) {},
         
         // Called after the container elements have been replaced
-        afterContainersReplaced: function () {},
+        afterContainersReplaced: function (newDoc) {},
         
         // Called after the new page container elements show animation
         // is complete

--- a/schmick.js
+++ b/schmick.js
@@ -28,8 +28,8 @@ window.Schmick = (function(window, $) {
                 oldPageHidden: function () {},
                 newPageUploadProgress: function (percentage) { },
                 newPageDownloadProgress: function (percentage) { },
-                beforeContainersReplaced: function () {},
-                afterContainersReplaced: function () {},
+                beforeContainersReplaced: function (newDoc) {},
+                afterContainersReplaced: function (newDoc) {},
                 newPageShown: function () {},
                 originalPageShown: function () {},
                 requestError: function (response, textStatus, errorThrown) {}
@@ -91,8 +91,8 @@ window.Schmick = (function(window, $) {
      *          oldPageHidden: function () {},
      *          newPageUploadProgress: function (percentage) { },
      *          newPageDownloadProgress: function (percentage) { },
-     *          beforeContainersReplaced: function () {},
-     *          afterContainersReplaced: function () {},
+     *          beforeContainersReplaced: function (newDoc) {},
+     *          afterContainersReplaced: function (newDoc) {},
      *          newPageShown: function () {},
      *          originalPageShown: function () {},
      *          requestError: function (response, textStatus, errorThrown) {}
@@ -519,7 +519,7 @@ window.Schmick = (function(window, $) {
         }
 
         // Perform the replacement with the new container elements while they are hidden
-        options.events.beforeContainersReplaced();
+        options.events.beforeContainersReplaced(newDoc);
         var containerSelector = options.container;
         var containerSelectors = containerSelector.split(',');
         containerSelectors.push('html > head > title');
@@ -532,7 +532,7 @@ window.Schmick = (function(window, $) {
             containerSelector = 'html';
             replaceContainerElements(['html'], window.document, newDoc);
         }
-        options.events.afterContainersReplaced();
+        options.events.afterContainersReplaced(newDoc);
 
         // Find the new container elements and ensure they are hidden
         var elements = $(containerSelector);


### PR DESCRIPTION
Sometimes it comes in handy to have access to the new document from inside an event. 

Let's say I have a heading outside of the container handled by Schmick but I want to replace it's content with the new heading from the loaded page.
When having access to the new document in a containersReplaced event I can handle this myself:

``` javascript
    Schmick.load({
        container: '.pjax',
        events: {
            beforeContainersReplaced: function(newDoc) {
                var newHeading = $(newDoc).find('.heading').text();
                $('.heading').text(newHeading);
            }
        }
    });
```
